### PR TITLE
feat: set up automated baseline generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,15 +120,12 @@ It runs the https://hub.docker.com/r/codeclimate/codeclimate docker image under 
         $ bundle binstubs codeclimate_diff
 
 
-6. Run the baseline and commit the result to the repo
+    Add codeclimate_diff_baseline.json to .gitignore
 
-    ```
-    ./bin/codeclimate_diff --baseline
-    ```
 
 ## Usage
 
-1. Create a feature branch for your work, and reset the baseline + commit (5 mins)
+1. Create a feature branch for your work
 
 2. Do some work
 
@@ -137,7 +134,7 @@ It runs the https://hub.docker.com/r/codeclimate/codeclimate docker image under 
     ```bash
     # runs on each file changed in your branch (about 10 secs per code file changed on your branch)
     ./bin/codeclimate_diff
-
+    # baseline is now generated on first run, to generate new baseline, delete the existing.
     OR
 
     # filters the changed files in your branch futher by a grep pattern

--- a/exe/codeclimate_diff
+++ b/exe/codeclimate_diff
@@ -23,10 +23,10 @@ OptionParser.new do |opts|
           "Grep pattern to filter files.  If provided, will filter the files changed on your branch further.")
 end.parse!(into: options)
 
-if options[:baseline]
-  CodeclimateDiff::Runner.generate_baseline
-elsif options[:"new-only"]
-  CodeclimateDiff::Runner.run_diff_on_branch(options[:pattern], always_analyze_all_files: options[:all], show_preexisting: false)
+if options[:"new-only"]
+  CodeclimateDiff::Runner.run_diff_on_branch(options[:pattern], always_analyze_all_files: options[:all],
+                                                                show_preexisting: false)
 else
-  CodeclimateDiff::Runner.run_diff_on_branch(options[:pattern], always_analyze_all_files: options[:all], show_preexisting: true)
+  CodeclimateDiff::Runner.run_diff_on_branch(options[:pattern], always_analyze_all_files: options[:all],
+                                                                show_preexisting: true)
 end

--- a/lib/codeclimate_diff/runner.rb
+++ b/lib/codeclimate_diff/runner.rb
@@ -86,8 +86,29 @@ module CodeclimateDiff
       puts "Done!"
     end
 
+    def self.setup_baseline_for_branch
+      main_branch = CodeclimateDiff.configuration["main_branch_name"] || "main"
+
+      project_repo = `basename $(pwd)`.strip
+
+      puts "Creating a temp worktree to generate the baseline..."
+      system("git worktree add ../temp-codeclimate #{main_branch}")
+
+      Dir.chdir("../temp-codeclimate") do
+        # Execute shell command in the '../temp-codeclimate' directory
+        generate_baseline
+
+        puts "Copying the baseline to #{project_repo}..."
+        system("cp codeclimate_diff_baseline.json ../#{project_repo}")
+      end
+
+      puts("Removing the temp worktree...")
+      system("git worktree remove ../temp-codeclimate")
+    end
+
     def self.run_diff_on_branch(pattern, always_analyze_all_files: false, show_preexisting: true)
-      CodeclimateWrapper.new.pull_latest_image
+      # CodeclimateWrapper.new.pull_latest_image
+      setup_baseline_for_branch
 
       changed_filenames = calculate_changed_filenames(pattern)
 

--- a/lib/codeclimate_diff/runner.rb
+++ b/lib/codeclimate_diff/runner.rb
@@ -95,7 +95,6 @@ module CodeclimateDiff
       system("git worktree add ../temp-codeclimate #{main_branch}")
 
       Dir.chdir("../temp-codeclimate") do
-        # Execute shell command in the '../temp-codeclimate' directory
         generate_baseline
 
         puts "Copying the baseline to #{project_repo}..."
@@ -107,8 +106,7 @@ module CodeclimateDiff
     end
 
     def self.run_diff_on_branch(pattern, always_analyze_all_files: false, show_preexisting: true)
-      # CodeclimateWrapper.new.pull_latest_image
-      setup_baseline_for_branch
+      setup_baseline_for_branch unless File.exist?("codeclimate_diff_baseline.json")
 
       changed_filenames = calculate_changed_filenames(pattern)
 


### PR DESCRIPTION
We've automated the generating baseline from main branch.

On first run of `./bin/codeclimate_diff`:
1. Makes a git worktree off main
2. Generates baseline 
3. Copies the baseline to the current WIP branch
4. Removes the worktree

This will save us a few steps of generating the baseline from main, copying to your branch and committing it.


