### PR TITLE
fix: remove the warning from docker image output

### DIFF
--- a/lib/codeclimate_diff/codeclimate_wrapper.rb
+++ b/lib/codeclimate_diff/codeclimate_wrapper.rb
@@ -9,7 +9,7 @@ module CodeclimateDiff
     def run_codeclimate(filename = "")
       docker_platform = CodeclimateDiff.configuration["docker_platform"] || "linux/amd64"
 
-      `docker run \
+      output = `docker run \
         --interactive --tty --rm \
         --env CODECLIMATE_CODE="$PWD" \
         --volume "$PWD":/code \
@@ -17,6 +17,8 @@ module CodeclimateDiff
         --volume /tmp/cc:/tmp/cc \
         --platform #{docker_platform} \
         codeclimate/codeclimate analyze -f json #{filename}`
+
+      output.gsub(/.*?(?=\[{)/im, "") # remove everything before the first json object (ie WARNINGS)
     end
 
     def pull_latest_image

--- a/lib/codeclimate_diff/version.rb
+++ b/lib/codeclimate_diff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CodeclimateDiff
-  VERSION = "0.1.13"
+  VERSION = "0.1.14"
 end


### PR DESCRIPTION
There seems to be a bit of a problem currently with a codeclimate warning fouling the json output, however upgrading seems to be complicated by codeclimate moving to a new tool (qlty.sh).

This fix just gobbles up the warning before it can break the json parsing.